### PR TITLE
refactor: remove unused password checking functionality from Win32Saver

### DIFF
--- a/rsWin32Saver/rsWin32Saver.cpp
+++ b/rsWin32Saver/rsWin32Saver.cpp
@@ -34,7 +34,6 @@ HWND mainWindow = 0;
 int childPreview = 0;
 int windowedSaver = 0;
 int reallyClose = 0;
-int checkingPassword = 0;
 int isSuspended = 0;
 int doingPreview = 0;
 int pfd_swap_exchange = 0;
@@ -45,75 +44,9 @@ int kStatistics = 0;
 POINT mousePoint;
 int closing = 0;
 int wakeThreshold = 4;  // must move 4 pixels to wake up
-typedef BOOL(WINAPI* VERIFYPASSWORDPROC) (HWND hwnd);
-typedef VOID(WINAPI* PASSWORDCHANGEPROC) (LPCSTR regKeyName, HWND hwnd, DWORD dwd, LPVOID lpv);
-
 static int startScreenSaver(HWND parent);
 static int openConfigBox(HWND parent);
 static int startSaverPreview(LPCTSTR str);
-
-//----------------------------------------------------------------------------
-// Password functions (only needed on Win95 and Win98)
-// I think this code still has trouble actually drawing the password checking box
-// Maybe I should install Win95 and test it.  Ha!
-
-BOOL
-checkPassword(HWND hwnd)
-{
-	OSVERSIONINFO osvi;
-	osvi.dwOSVersionInfoSize = sizeof(osvi);
-	GetVersionEx(&osvi);
-	if (osvi.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS)
-	{  // this is Win95 or Win98
-		HINSTANCE passwordcpl = LoadLibrary("PASSWORD.CPL");
-		if (passwordcpl == NULL)
-			return TRUE;
-
-		VERIFYPASSWORDPROC verifyPwdProc;
-		verifyPwdProc = (VERIFYPASSWORDPROC)GetProcAddress(passwordcpl, "VerifyScreenSavePwd");
-		if (verifyPwdProc == NULL)
-		{
-			FreeLibrary(passwordcpl);
-			return TRUE;
-		}
-
-		BOOL junk;
-		SystemParametersInfo(SPI_SCREENSAVERRUNNING, TRUE, &junk, 0);  // disable ctrl-alt-delete
-		checkingPassword = TRUE;
-		BOOL verified = verifyPwdProc(hwnd);
-		checkingPassword = FALSE;
-		SystemParametersInfo(SPI_SCREENSAVERRUNNING, FALSE, &junk, 0);
-		FreeLibrary(passwordcpl);
-
-		return verified;
-	}
-
-	return TRUE;
-}
-
-void
-changePassword(HWND hwnd)
-{
-	OSVERSIONINFO osvi;
-	osvi.dwOSVersionInfoSize = sizeof(osvi);
-	GetVersionEx(&osvi);
-	if (osvi.dwPlatformId == VER_PLATFORM_WIN32_WINDOWS)
-	{  // this is Win95 or Win98
-		HINSTANCE mprdll = LoadLibrary("MPR.DLL");
-		if (mprdll == NULL)
-			return;
-
-		PASSWORDCHANGEPROC PwdChangePassword = (PASSWORDCHANGEPROC)GetProcAddress(mprdll, "PwdChangePasswordA");
-		if (PwdChangePassword == NULL)
-		{
-			FreeLibrary(mprdll);
-			return;
-		}
-
-		PwdChangePassword("SCRSAVE", hwnd, 0, 0);
-		FreeLibrary(mprdll);
-	}
-}
 
 //----------------------------------------------------------------------------
 
@@ -133,17 +66,9 @@ defScreenSaverProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
 				// NT will sometimes send a WM_CLOSE on its own.
 				if (reallyClose == 0)
 					return 0;
-				// Check password on Win95 or Win98 (NT takes care of this on its own)
-				if (checkPassword(hwnd) == FALSE)
-				{
-					GetCursorPos(&mousePoint);  // reset mouse position if not quitting
-					return 0;
-				}
 				break;
 			default: {
 				POINT movePoint, checkPoint;
-				if (checkingPassword)
-					break;
 				switch (msg)
 				{
 					case WM_SHOWWINDOW:
@@ -580,10 +505,6 @@ WinMain(HINSTANCE inst, HINSTANCE prevInst, LPSTR cmdLine, int cmdShow)
 			case TEXT('/'):
 				commandLine++;
 				break;
-			case TEXT('a'):  // change password on Win95
-			case TEXT('A'):
-				changePassword(parent);
-				return -1;
 			case TEXT('c'):  // open "settings" dialog box
 			case TEXT('C'):
 				return openConfigBox(GetForegroundWindow());

--- a/rsWin32Saver/rsWin32Saver.h
+++ b/rsWin32Saver/rsWin32Saver.h
@@ -56,7 +56,6 @@
 // The following globals are defined in rsWin32Saver.cpp
 extern HINSTANCE mainInstance;
 extern HWND mainWindow;
-extern int checkingPassword;  // A saver should check this and stop drawing if true
 extern int isSuspended;  // power save mode
 extern int doingPreview;  // Previews take extra long to initialize because Windows
 // has lots of screwy resource hogging problems.  It's good to check this so that you

--- a/rsWin32Saver/rsWin32Saver.vcxproj
+++ b/rsWin32Saver/rsWin32Saver.vcxproj
@@ -55,7 +55,6 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />


### PR DESCRIPTION
This pull request removes legacy password management code that was only relevant for Windows 95/98, simplifying the codebase and reducing maintenance overhead. The changes eliminate password verification and change functionality, as well as related variables and references, since modern Windows versions handle screen saver security internally.

**Removal of legacy password management (Win95/98):**

* Deleted the `checkPassword` and `changePassword` functions, their typedefs, and all related logic from `rsWin32Saver.cpp`, as well as the `checkingPassword` variable and its usage. This includes removing password checks on close and the `/a` command-line option for changing the password. [[1]](diffhunk://#diff-3f46732853afb9f6be7f43b242bc4f568298e674b00c76115c87fb16418b7643L48-L117) [[2]](diffhunk://#diff-3f46732853afb9f6be7f43b242bc4f568298e674b00c76115c87fb16418b7643L37) [[3]](diffhunk://#diff-3f46732853afb9f6be7f43b242bc4f568298e674b00c76115c87fb16418b7643L136-L146) [[4]](diffhunk://#diff-3f46732853afb9f6be7f43b242bc4f568298e674b00c76115c87fb16418b7643L583-L586) [[5]](diffhunk://#diff-db287bfd802ea95d3e0a4d438ee26a99c0e6100b3cd1b1d4ef12399bb1663c17L59)

**Project configuration cleanup:**

* Removed the deprecated `MinimalRebuild` project setting from `rsWin32Saver.vcxproj` to modernize the build configuration.