### PR TITLE
chore: fix deprecated settings in projects

### DIFF
--- a/Implicit/Implicit.vcxproj
+++ b/Implicit/Implicit.vcxproj
@@ -56,7 +56,6 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>..;..\..\opengl-headers;..\..\3rdparty;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />

--- a/Implicit/Implicit.vcxproj
+++ b/Implicit/Implicit.vcxproj
@@ -54,7 +54,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
       <Optimization>Disabled</Optimization>
-      <AdditionalIncludeDirectories>..;..\..\3rdparty;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;..\..\opengl-headers;..\..\3rdparty;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
@@ -72,7 +72,7 @@
     <ClCompile>
       <Optimization>Full</Optimization>
       <WholeProgramOptimization>true</WholeProgramOptimization>
-      <AdditionalIncludeDirectories>..;..\..\3rdparty;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;..\..\opengl-headers;..\..\3rdparty;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;GL_GLEXT_PROTOTYPES ;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <FloatingPointModel>Fast</FloatingPointModel>

--- a/Rgbhsl/Rgbhsl.vcxproj
+++ b/Rgbhsl/Rgbhsl.vcxproj
@@ -55,7 +55,6 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />

--- a/rsMath/rsMath.vcxproj
+++ b/rsMath/rsMath.vcxproj
@@ -55,7 +55,6 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />

--- a/rsText/rsText.vcxproj
+++ b/rsText/rsText.vcxproj
@@ -55,7 +55,6 @@
       <Optimization>Disabled</Optimization>
       <AdditionalIncludeDirectories>%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>WIN32;_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <MinimalRebuild>true</MinimalRebuild>
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader />


### PR DESCRIPTION
This pull request updates several Visual Studio project files to improve build configuration and include necessary OpenGL headers. The most significant change is adding the `opengl-headers` directory to the include paths for the `Implicit` project. Additionally, the `MinimalRebuild` option is removed from multiple projects' debug configurations, likely to modernize the build settings and avoid deprecated options.

**Project configuration updates:**

* Added `..\..\opengl-headers` to the `AdditionalIncludeDirectories` for both Debug and Release configurations in `Implicit.vcxproj`, ensuring OpenGL headers are available during compilation. [[1]](diffhunk://#diff-45f163b8c8f329916762433138482eb473706815dfb2cacca3710e57a2ce0b69L57-L59) [[2]](diffhunk://#diff-45f163b8c8f329916762433138482eb473706815dfb2cacca3710e57a2ce0b69L75-R74)

**Build settings cleanup:**

* Removed the `MinimalRebuild` option from the Debug configuration in the following project files to modernize and simplify build settings:
  - `Implicit.vcxproj`
  - `Rgbhsl.vcxproj`
  - `rsMath.vcxproj`
  - `rsText.vcxproj`