### PR TITLE
feat: cleanup in code in Rgbhsl library

### DIFF
--- a/Implicit/Makefile
+++ b/Implicit/Makefile
@@ -1,6 +1,7 @@
-INCLUDE = -I..
-COMPILE = g++ $(INCLUDE) -std=c++14 -O3 -DGL_GLEXT_PROTOTYPES -msse -mfpmath=sse
-OBJECTS = impCubeTables.o \
+INCLUDE  = -I..
+CXX      ?= g++
+CXXFLAGS += -std=c++14 -O3 -DGL_GLEXT_PROTOTYPES -msse -mfpmath=sse
+OBJECTS  = impCubeTables.o \
 	impCubeVolume.o \
 	impSurface.o \
 	impShape.o \
@@ -23,4 +24,4 @@ clean:
 .SUFFIXES: .cpp .o
 
 .cpp.o:
-	$(COMPILE) -o $@ -c $<
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -o $@ -c $<

--- a/Implicit/Makefile
+++ b/Implicit/Makefile
@@ -1,6 +1,6 @@
 INCLUDE  = -I..
 CXX      ?= g++
-CXXFLAGS += -std=c++14 -O3 -DGL_GLEXT_PROTOTYPES -msse -mfpmath=sse
+CXXFLAGS ?= -std=c++14 -O3 -DGL_GLEXT_PROTOTYPES -msse -mfpmath=sse
 OBJECTS  = impCubeTables.o \
 	impCubeVolume.o \
 	impSurface.o \

--- a/Implicit/Makefile
+++ b/Implicit/Makefile
@@ -1,6 +1,7 @@
 INCLUDE  = -I..
 CXX      ?= g++
-CXXFLAGS ?= -std=c++14 -O3 -DGL_GLEXT_PROTOTYPES -msse -mfpmath=sse
+CXXFLAGS ?= -std=c++14 -O3 -msse -mfpmath=sse
+CPPFLAGS ?= -DGL_GLEXT_PROTOTYPES
 OBJECTS  = impCubeTables.o \
 	impCubeVolume.o \
 	impSurface.o \
@@ -24,4 +25,4 @@ clean:
 .SUFFIXES: .cpp .o
 
 .cpp.o:
-	$(CXX) $(CXXFLAGS) $(INCLUDE) -o $@ -c $<
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(INCLUDE) -o $@ -c $<

--- a/Implicit/Makefile
+++ b/Implicit/Makefile
@@ -1,5 +1,5 @@
 INCLUDE = -I..
-COMPILE = g++ $(INCLUDE) -O3 -DGL_GLEXT_PROTOTYPES -msse -mfpmath=sse
+COMPILE = g++ $(INCLUDE) -std=c++14 -O3 -DGL_GLEXT_PROTOTYPES -msse -mfpmath=sse
 OBJECTS = impCubeTables.o \
 	impCubeVolume.o \
 	impSurface.o \

--- a/Implicit/impSurface.h
+++ b/Implicit/impSurface.h
@@ -25,6 +25,7 @@
 #include <windows.h>
 #endif
 #include <vector>
+#include <cstddef>
 
 #include <GL/gl.h>
 #include <GL/glext.h>

--- a/Rgbhsl/Makefile
+++ b/Rgbhsl/Makefile
@@ -1,5 +1,5 @@
 INCLUDE = -I..
-COMPILE = g++ $(INCLUDE) -O3
+COMPILE = g++ $(INCLUDE) -std=c++14 -O3
 OBJECTS = Rgbhsl.o
 
 

--- a/Rgbhsl/Makefile
+++ b/Rgbhsl/Makefile
@@ -1,6 +1,6 @@
 INCLUDE  = -I..
 CXX      ?= g++
-CXXFLAGS += -std=c++14 -O3
+CXXFLAGS ?= -std=c++14 -O3
 OBJECTS  = Rgbhsl.o
 
 

--- a/Rgbhsl/Makefile
+++ b/Rgbhsl/Makefile
@@ -1,6 +1,7 @@
-INCLUDE = -I..
-COMPILE = g++ $(INCLUDE) -std=c++14 -O3
-OBJECTS = Rgbhsl.o
+INCLUDE  = -I..
+CXX      ?= g++
+CXXFLAGS += -std=c++14 -O3
+OBJECTS  = Rgbhsl.o
 
 
 all: $(OBJECTS)
@@ -10,4 +11,4 @@ all: $(OBJECTS)
 .SUFFIXES: .cpp .o
 
 .cpp.o:
-	$(COMPILE) -o $@ -c $<
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -o $@ -c $<

--- a/Rgbhsl/Rgbhsl.cpp
+++ b/Rgbhsl/Rgbhsl.cpp
@@ -33,6 +33,7 @@ void
 rgb2hsl(float r, float g, float b, float &h, float &s, float &l)
 {
 	int huezone = 0;
+	float rr, gg, bb;
 
 	// find huezone
 	if (r >= g)
@@ -81,59 +82,89 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l)
 		return;
 	}
 
+	// Normalize channels by luminosity so hue/saturation do not depend on brightness.
+	switch (huezone)
+	{
+		case 0:
+		case 5:
+			rr = 1.0f;
+			gg = g / l;
+			bb = b / l;
+			break;
+		case 1:
+		case 3:
+			gg = 1.0f;
+			rr = r / l;
+			bb = b / l;
+			break;
+		default:
+			bb = 1.0f;
+			rr = r / l;
+			gg = g / l;
+	}
+
 	// saturation
 	switch (huezone)
 	{
 		case 0:
 		case 1:
-			s = 1.0f - b;
+			s = 1.0f - bb;
 			if (s < kEpsilon)
 			{
 				s = 0.0f;
 				h = 0.0f;
 				return;
 			}
+			bb = 0.0f;
+			rr = 1.0f - ((1.0f - rr) / s);
+			gg = 1.0f - ((1.0f - gg) / s);
 			break;
 		case 2:
 		case 3:
-			s = 1.0f - r;
+			s = 1.0f - rr;
 			if (s < kEpsilon)
 			{
 				s = 0.0f;
 				h = 0.0f;
 				return;
 			}
+			rr = 0.0f;
+			gg = 1.0f - ((1.0f - gg) / s);
+			bb = 1.0f - ((1.0f - bb) / s);
 			break;
 		default:
-			s = 1.0f - g;
+			s = 1.0f - gg;
 			if (s < kEpsilon)
 			{
 				s = 0.0f;
 				h = 0.0f;
 				return;
 			}
+			gg = 0.0f;
+			rr = 1.0f - ((1.0f - rr) / s);
+			bb = 1.0f - ((1.0f - bb) / s);
 	}
 
 	// hue
 	switch (huezone)
 	{
 		case 0:
-			h = g / 6.0f;
+			h = gg / 6.0f;
 			break;
 		case 1:
-			h = ((1.0f - r) / 6.0f) + kOneSixth;
+			h = ((1.0f - rr) / 6.0f) + kOneSixth;
 			break;
 		case 2:
-			h = (b / 6.0f) + kOneThird;
+			h = (bb / 6.0f) + kOneThird;
 			break;
 		case 3:
-			h = ((1.0f - g) / 6.0f) + kOneHalf;
+			h = ((1.0f - gg) / 6.0f) + kOneHalf;
 			break;
 		case 4:
-			h = (r / 6.0f) + kTwoThirds;
+			h = (rr / 6.0f) + kTwoThirds;
 			break;
 		default:
-			h = ((1.0f - b) / 6.0f) + kFiveSixths;
+			h = ((1.0f - bb) / 6.0f) + kFiveSixths;
 	}
 }
 

--- a/Rgbhsl/Rgbhsl.cpp
+++ b/Rgbhsl/Rgbhsl.cpp
@@ -30,10 +30,9 @@ static constexpr float kTwoThirds  = 2.0f / 3.0f;
 static constexpr float kFiveSixths = 5.0f / 6.0f;
 
 void
-rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept
+rgb2hsl(float r, float g, float b, float &h, float &s, float &l)
 {
 	int huezone = 0;
-	float rr, gg, bb;
 
 	// find huezone
 	if (r >= g)
@@ -82,26 +81,6 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept
 		return;
 	}
 
-	switch (huezone)
-	{
-		case 0:
-		case 5:
-			rr = 1.0f;
-			gg = g / l;
-			bb = b / l;
-			break;
-		case 1:
-		case 2:
-			gg = 1.0f;
-			rr = r / l;
-			bb = b / l;
-			break;
-		default:
-			bb = 1.0f;
-			rr = r / l;
-			gg = g / l;
-	}
-
 	// saturation
 	switch (huezone)
 	{
@@ -114,9 +93,6 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept
 				h = 0.0f;
 				return;
 			}
-			bb = 0.0f;
-			rr = 1.0f - ((1.0f - rr) / s);
-			gg = 1.0f - ((1.0f - gg) / s);
 			break;
 		case 2:
 		case 3:
@@ -127,9 +103,6 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept
 				h = 0.0f;
 				return;
 			}
-			rr = 0.0f;
-			gg = 1.0f - ((1.0f - gg) / s);
-			bb = 1.0f - ((1.0f - bb) / s);
 			break;
 		default:
 			s = 1.0f - g;
@@ -139,9 +112,6 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept
 				h = 0.0f;
 				return;
 			}
-			gg = 0.0f;
-			rr = 1.0f - ((1.0f - rr) / s);
-			bb = 1.0f - ((1.0f - bb) / s);
 	}
 
 	// hue
@@ -168,7 +138,7 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept
 }
 
 void
-hsl2rgb(float h, float s, float l, float &r, float &g, float &b) noexcept
+hsl2rgb(float h, float s, float l, float &r, float &g, float &b)
 {
 	// hue influence
 	h = std::fmod(h, 1.0f);
@@ -234,7 +204,7 @@ hsl2rgb(float h, float s, float l, float &r, float &g, float &b) noexcept
 void
 hslTween(float h1, float s1, float l1,
 	float h2, float s2, float l2, float tween, int direction,
-	float &outh, float &outs, float &outl) noexcept
+	float &outh, float &outs, float &outl)
 {
 	// hue
 	if (!direction)
@@ -270,7 +240,7 @@ hslTween(float h1, float s1, float l1,
 void
 rgbTween(float r1, float g1, float b1,
 	float r2, float g2, float b2, float tween, int direction,
-	float &outr, float &outg, float &outb) noexcept
+	float &outr, float &outg, float &outb)
 {
 	float h1, s1, l1, h2, s2, l2, outh, outs, outl;
 

--- a/Rgbhsl/Rgbhsl.cpp
+++ b/Rgbhsl/Rgbhsl.cpp
@@ -108,7 +108,12 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept
 		case 0:
 		case 1:
 			s = 1.0f - b;
-			if (s < kEpsilon) { s = 0.0f; h = 0.0f; return; }
+			if (s < kEpsilon)
+			{
+				s = 0.0f;
+				h = 0.0f;
+				return;
+			}
 			bb = 0.0f;
 			rr = 1.0f - ((1.0f - rr) / s);
 			gg = 1.0f - ((1.0f - gg) / s);
@@ -116,14 +121,24 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept
 		case 2:
 		case 3:
 			s = 1.0f - r;
-			if (s < kEpsilon) { s = 0.0f; h = 0.0f; return; }
+			if (s < kEpsilon)
+			{
+				s = 0.0f;
+				h = 0.0f;
+				return;
+			}
 			rr = 0.0f;
 			gg = 1.0f - ((1.0f - gg) / s);
 			bb = 1.0f - ((1.0f - bb) / s);
 			break;
 		default:
 			s = 1.0f - g;
-			if (s < kEpsilon) { s = 0.0f; h = 0.0f; return; }
+			if (s < kEpsilon)
+			{
+				s = 0.0f;
+				h = 0.0f;
+				return;
+			}
 			gg = 0.0f;
 			rr = 1.0f - ((1.0f - rr) / s);
 			bb = 1.0f - ((1.0f - bb) / s);

--- a/Rgbhsl/Rgbhsl.cpp
+++ b/Rgbhsl/Rgbhsl.cpp
@@ -155,10 +155,10 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l)
 			h = ((1.0f - rr) / 6.0f) + kOneSixth;
 			break;
 		case 2:
-			h = (bb / 6.0f) + kOneThird;
+			h = ((1.0f - gg) / 6.0f) + kOneHalf;
 			break;
 		case 3:
-			h = ((1.0f - gg) / 6.0f) + kOneHalf;
+			h = (bb / 6.0f) + kOneThird;
 			break;
 		case 4:
 			h = (rr / 6.0f) + kTwoThirds;

--- a/Rgbhsl/Rgbhsl.cpp
+++ b/Rgbhsl/Rgbhsl.cpp
@@ -20,10 +20,17 @@
 
 #include "Rgbhsl.h"
 
-#include <math.h>
+#include <cmath>
+
+static constexpr float kEpsilon    = 1e-7f;
+static constexpr float kOneSixth   = 1.0f / 6.0f;
+static constexpr float kOneThird   = 1.0f / 3.0f;
+static constexpr float kOneHalf    = 0.5f;
+static constexpr float kTwoThirds  = 2.0f / 3.0f;
+static constexpr float kFiveSixths = 5.0f / 6.0f;
 
 void
-rgb2hsl(float r, float g, float b, float &h, float &s, float &l)
+rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept
 {
 	int huezone = 0;
 	float rr, gg, bb;
@@ -75,10 +82,10 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l)
 			rr = r / l;
 			gg = g / l;
 	}
-	if (l == 0.0)
+	if (l < kEpsilon)
 	{
-		h = 0.0;
-		s = 1.0;
+		h = 0.0f;
+		s = 1.0f;
 		return;
 	}
 
@@ -88,6 +95,7 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l)
 		case 0:
 		case 1:
 			s = 1.0f - b;
+			if (s < kEpsilon) { s = 0.0f; h = 0.0f; return; }
 			bb = 0.0f;
 			rr = 1.0f - ((1.0f - rr) / s);
 			gg = 1.0f - ((1.0f - gg) / s);
@@ -95,12 +103,14 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l)
 		case 2:
 		case 3:
 			s = 1.0f - r;
+			if (s < kEpsilon) { s = 0.0f; h = 0.0f; return; }
 			rr = 0.0f;
 			gg = 1.0f - ((1.0f - gg) / s);
 			bb = 1.0f - ((1.0f - bb) / s);
 			break;
 		default:
 			s = 1.0f - g;
+			if (s < kEpsilon) { s = 0.0f; h = 0.0f; return; }
 			gg = 0.0f;
 			rr = 1.0f - ((1.0f - rr) / s);
 			bb = 1.0f - ((1.0f - bb) / s);
@@ -113,70 +123,70 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l)
 			h = g / 6.0f;
 			break;
 		case 1:
-			h = ((1.0f - r) / 6.0f) + 0.166667f;
+			h = ((1.0f - r) / 6.0f) + kOneSixth;
 			break;
 		case 2:
-			h = (b / 6.0f) + 0.333333f;
+			h = (b / 6.0f) + kOneThird;
 			break;
 		case 3:
-			h = ((1.0f - g) / 6.0f) + 0.5f;
+			h = ((1.0f - g) / 6.0f) + kOneHalf;
 			break;
 		case 4:
-			h = (r / 6.0f) + 0.666667f;
+			h = (r / 6.0f) + kTwoThirds;
 			break;
 		default:
-			h = ((1.0f - b) / 6.0f) + 0.833333f;
+			h = ((1.0f - b) / 6.0f) + kFiveSixths;
 	}
 }
 
 void
-hsl2rgb(float h, float s, float l, float &r, float &g, float &b)
+hsl2rgb(float h, float s, float l, float &r, float &g, float &b) noexcept
 {
 	// hue influence
-	h = fmodf(h, 1.0f);
-	if (h < 0.166667)
+	h = std::fmod(h, 1.0f);
+	if (h < kOneSixth)
 	{  // full red, some green
-		r = 1.0;
+		r = 1.0f;
 		g = h * 6.0f;
-		b = 0.0;
+		b = 0.0f;
 	}
 	else
 	{
-		if (h < 0.5)
+		if (h < kOneHalf)
 		{  // full green
-			g = 1.0;
-			if (h < 0.333333)
+			g = 1.0f;
+			if (h < kOneThird)
 			{  // some red
-				r = 1.0f - ((h - 0.166667f) * 6.0f);
-				b = 0.0;
+				r = 1.0f - ((h - kOneSixth) * 6.0f);
+				b = 0.0f;
 			}
 			else
 			{  // some blue
-				b = (h - 0.333333f) * 6.0f;
-				r = 0.0;
+				b = (h - kOneThird) * 6.0f;
+				r = 0.0f;
 			}
 		}
 		else
 		{
-			if (h < 0.833333)
+			if (h < kFiveSixths)
 			{  // full blue
-				b = 1.0;
-				if (h < 0.666667)
+				b = 1.0f;
+				if (h < kTwoThirds)
 				{  // some green
-					g = 1.0f - ((h - 0.5f) * 6.0f);
-					r = 0.0;
+					g = 1.0f - ((h - kOneHalf) * 6.0f);
+					r = 0.0f;
 				}
 				else
 				{  // some red
-					r = (h - 0.666667f) * 6.0f;
-					g = 0.0;
+					r = (h - kTwoThirds) * 6.0f;
+					g = 0.0f;
 				}
 			}
 			else
 			{  // full red, some blue
-				r = 1.0;
-				b = 1.0f - ((h - 0.833333f) * 6.0f);
-				g = 0.0;
+				r = 1.0f;
+				b = 1.0f - ((h - kFiveSixths) * 6.0f);
+				g = 0.0f;
 			}
 		}
 	}
@@ -195,7 +205,7 @@ hsl2rgb(float h, float s, float l, float &r, float &g, float &b)
 void
 hslTween(float h1, float s1, float l1,
 	float h2, float s2, float l2, float tween, int direction,
-	float &outh, float &outs, float &outl)
+	float &outh, float &outs, float &outl) noexcept
 {
 	// hue
 	if (!direction)
@@ -205,8 +215,8 @@ hslTween(float h1, float s1, float l1,
 		else
 		{
 			outh = h1 + (tween * (1.0f - (h1 - h2)));
-			if (outh > 1.0)
-				outh -= 1.0;
+			if (outh > 1.0f)
+				outh -= 1.0f;
 		}
 	}
 	else
@@ -216,8 +226,8 @@ hslTween(float h1, float s1, float l1,
 		else
 		{
 			outh = h1 - (tween * (1.0f - (h2 - h1)));
-			if (outh < 0.0)
-				outh += 1.0;
+			if (outh < 0.0f)
+				outh += 1.0f;
 		}
 	}
 
@@ -231,7 +241,7 @@ hslTween(float h1, float s1, float l1,
 void
 rgbTween(float r1, float g1, float b1,
 	float r2, float g2, float b2, float tween, int direction,
-	float &outr, float &outg, float &outb)
+	float &outr, float &outg, float &outb) noexcept
 {
 	float h1, s1, l1, h2, s2, l2, outh, outs, outl;
 

--- a/Rgbhsl/Rgbhsl.cpp
+++ b/Rgbhsl/Rgbhsl.cpp
@@ -84,6 +84,7 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept
 	}
 	if (l < kEpsilon)
 	{
+		// Black: h and l are zero; s is arbitrarily set to 1.0 (legacy convention).
 		h = 0.0f;
 		s = 1.0f;
 		return;
@@ -144,6 +145,7 @@ hsl2rgb(float h, float s, float l, float &r, float &g, float &b) noexcept
 {
 	// hue influence
 	h = std::fmod(h, 1.0f);
+	if (h < 0.0f) h += 1.0f;
 	if (h < kOneSixth)
 	{  // full red, some green
 		r = 1.0f;

--- a/Rgbhsl/Rgbhsl.cpp
+++ b/Rgbhsl/Rgbhsl.cpp
@@ -65,29 +65,41 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept
 		case 0:
 		case 5:
 			l = r;
+			break;
+		case 1:
+		case 2:
+			l = g;
+			break;
+		default:
+			l = b;
+	}
+
+	if (l < kEpsilon)
+	{
+		// Near-black: l is very small, h is set to zero, and s is arbitrarily set to 1.0 (legacy convention).
+		h = 0.0f;
+		s = 1.0f;
+		return;
+	}
+
+	switch (huezone)
+	{
+		case 0:
+		case 5:
 			rr = 1.0f;
 			gg = g / l;
 			bb = b / l;
 			break;
 		case 1:
 		case 2:
-			l = g;
 			gg = 1.0f;
 			rr = r / l;
 			bb = b / l;
 			break;
 		default:
-			l = b;
 			bb = 1.0f;
 			rr = r / l;
 			gg = g / l;
-	}
-	if (l < kEpsilon)
-	{
-		// Black: h and l are zero; s is arbitrarily set to 1.0 (legacy convention).
-		h = 0.0f;
-		s = 1.0f;
-		return;
 	}
 
 	// saturation

--- a/Rgbhsl/Rgbhsl.cpp
+++ b/Rgbhsl/Rgbhsl.cpp
@@ -149,22 +149,22 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l)
 	switch (huezone)
 	{
 		case 0:
-			h = gg / 6.0f;
+			h = gg * kOneSixth;
 			break;
 		case 1:
-			h = ((1.0f - rr) / 6.0f) + kOneSixth;
+			h = (1.0f - rr) * kOneSixth + kOneSixth;
 			break;
 		case 2:
-			h = ((1.0f - gg) / 6.0f) + kOneHalf;
+			h = (1.0f - gg) * kOneSixth + kOneHalf;
 			break;
 		case 3:
-			h = (bb / 6.0f) + kOneThird;
+			h = bb * kOneSixth + kOneThird;
 			break;
 		case 4:
-			h = (rr / 6.0f) + kTwoThirds;
+			h = rr * kOneSixth + kTwoThirds;
 			break;
 		default:
-			h = ((1.0f - bb) / 6.0f) + kFiveSixths;
+			h = (1.0f - bb) * kOneSixth + kFiveSixths;
 	}
 }
 

--- a/Rgbhsl/Rgbhsl.cpp
+++ b/Rgbhsl/Rgbhsl.cpp
@@ -76,9 +76,9 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept
 
 	if (l < kEpsilon)
 	{
-		// Near-black: l is very small, h is set to zero, and s is arbitrarily set to 1.0 (legacy convention).
+		// Near-black: l is very small; set achromatic output so round-trips stay grayscale.
 		h = 0.0f;
-		s = 1.0f;
+		s = 0.0f;
 		return;
 	}
 

--- a/Rgbhsl/Rgbhsl.cpp
+++ b/Rgbhsl/Rgbhsl.cpp
@@ -66,7 +66,7 @@ rgb2hsl(float r, float g, float b, float &h, float &s, float &l)
 			l = r;
 			break;
 		case 1:
-		case 2:
+		case 3:
 			l = g;
 			break;
 		default:

--- a/Rgbhsl/Rgbhsl.h
+++ b/Rgbhsl/Rgbhsl.h
@@ -27,9 +27,9 @@
 #ifndef RGBHSL_H
 #define RGBHSL_H
 
-void rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept;
+void rgb2hsl(float r, float g, float b, float &h, float &s, float &l);
 
-void hsl2rgb(float h, float s, float l, float &r, float &g, float &b) noexcept;
+void hsl2rgb(float h, float s, float l, float &r, float &g, float &b);
 
 // For these 'tween functions, a tween value of 0.0 will output the first
 // color while a tween value of 1.0 will output the second color.
@@ -38,10 +38,10 @@ void hsl2rgb(float h, float s, float l, float &r, float &g, float &b) noexcept;
 // 1 does the opposite.
 void hslTween(float h1, float s1, float l1,
 	float h2, float s2, float l2, float tween, int direction,
-	float &outh, float &outs, float &outl) noexcept;
+	float &outh, float &outs, float &outl);
 
 void rgbTween(float r1, float g1, float b1,
 	float r2, float g2, float b2, float tween, int direction,
-	float &outr, float &outg, float &outb) noexcept;
+	float &outr, float &outg, float &outb);
 
 #endif // RGBHSL_H

--- a/Rgbhsl/Rgbhsl.h
+++ b/Rgbhsl/Rgbhsl.h
@@ -27,9 +27,9 @@
 #ifndef RGBHSL_H
 #define RGBHSL_H
 
-void rgb2hsl(float r, float g, float b, float &h, float &s, float &l);
+void rgb2hsl(float r, float g, float b, float &h, float &s, float &l) noexcept;
 
-void hsl2rgb(float h, float s, float l, float &r, float &g, float &b);
+void hsl2rgb(float h, float s, float l, float &r, float &g, float &b) noexcept;
 
 // For these 'tween functions, a tween value of 0.0 will output the first
 // color while a tween value of 1.0 will output the second color.
@@ -38,10 +38,10 @@ void hsl2rgb(float h, float s, float l, float &r, float &g, float &b);
 // 1 does the opposite.
 void hslTween(float h1, float s1, float l1,
 	float h2, float s2, float l2, float tween, int direction,
-	float &outh, float &outs, float &outl);
+	float &outh, float &outs, float &outl) noexcept;
 
 void rgbTween(float r1, float g1, float b1,
 	float r2, float g2, float b2, float tween, int direction,
-	float &outr, float &outg, float &outb);
+	float &outr, float &outg, float &outb) noexcept;
 
 #endif // RGBHSL_H

--- a/rsMath/Makefile
+++ b/rsMath/Makefile
@@ -1,6 +1,6 @@
 INCLUDE  = -I..
 CXX      ?= g++
-CXXFLAGS += -std=c++14 -O3
+CXXFLAGS ?= -std=c++14 -O3
 OBJECTS  = rsVec.o \
 	rsVec4.o \
 	rsQuat.o \

--- a/rsMath/Makefile
+++ b/rsMath/Makefile
@@ -1,6 +1,7 @@
-INCLUDE = -I..
-COMPILE = g++ $(INCLUDE) -std=c++14 -O3
-OBJECTS = rsVec.o \
+INCLUDE  = -I..
+CXX      ?= g++
+CXXFLAGS += -std=c++14 -O3
+OBJECTS  = rsVec.o \
 	rsVec4.o \
 	rsQuat.o \
 	rsMatrix.o
@@ -15,4 +16,4 @@ clean:
 .SUFFIXES: .cpp .o
 
 .cpp.o:
-	$(COMPILE) -o $@ -c $<
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -o $@ -c $<

--- a/rsMath/Makefile
+++ b/rsMath/Makefile
@@ -1,5 +1,5 @@
 INCLUDE = -I..
-COMPILE = g++ $(INCLUDE) -O3
+COMPILE = g++ $(INCLUDE) -std=c++14 -O3
 OBJECTS = rsVec.o \
 	rsVec4.o \
 	rsQuat.o \

--- a/rsText/Makefile
+++ b/rsText/Makefile
@@ -1,6 +1,6 @@
 INCLUDE  = -I..
 CXX      ?= g++
-CXXFLAGS += -std=c++14 -O3
+CXXFLAGS ?= -std=c++14 -O3
 OBJECTS  = rsText.o
 
 

--- a/rsText/Makefile
+++ b/rsText/Makefile
@@ -1,6 +1,7 @@
-INCLUDE = -I..
-COMPILE = g++ $(INCLUDE) -std=c++14 -O3
-OBJECTS = rsText.o
+INCLUDE  = -I..
+CXX      ?= g++
+CXXFLAGS += -std=c++14 -O3
+OBJECTS  = rsText.o
 
 
 all: $(OBJECTS)
@@ -10,4 +11,4 @@ all: $(OBJECTS)
 .SUFFIXES: .cpp .o
 
 .cpp.o:
-	$(COMPILE) -o $@ -c $<
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -o $@ -c $<

--- a/rsText/Makefile
+++ b/rsText/Makefile
@@ -1,5 +1,5 @@
 INCLUDE = -I..
-COMPILE = g++ $(INCLUDE) -O3
+COMPILE = g++ $(INCLUDE) -std=c++14 -O3
 OBJECTS = rsText.o
 
 

--- a/rsXScreenSaver/Makefile
+++ b/rsXScreenSaver/Makefile
@@ -1,6 +1,7 @@
-INCLUDE = -I..
-COMPILE = g++ $(INCLUDE) -std=c++14 -O3
-OBJECTS = rsXScreenSaver.o
+INCLUDE  = -I..
+CXX      ?= g++
+CXXFLAGS += -std=c++14 -O3
+OBJECTS  = rsXScreenSaver.o
 
 
 all: $(OBJECTS)
@@ -13,4 +14,4 @@ clean:
 .SUFFIXES: .cpp .o
 
 .cpp.o:
-	$(COMPILE) -o $@ -c $<
+	$(CXX) $(CXXFLAGS) $(INCLUDE) -o $@ -c $<

--- a/rsXScreenSaver/Makefile
+++ b/rsXScreenSaver/Makefile
@@ -1,6 +1,6 @@
 INCLUDE  = -I..
 CXX      ?= g++
-CXXFLAGS += -std=c++14 -O3
+CXXFLAGS ?= -std=c++14 -O3
 OBJECTS  = rsXScreenSaver.o
 
 

--- a/rsXScreenSaver/Makefile
+++ b/rsXScreenSaver/Makefile
@@ -1,5 +1,5 @@
 INCLUDE = -I..
-COMPILE = g++ $(INCLUDE) -O3
+COMPILE = g++ $(INCLUDE) -std=c++14 -O3
 OBJECTS = rsXScreenSaver.o
 
 

--- a/tests/test_Rgbhsl.cpp
+++ b/tests/test_Rgbhsl.cpp
@@ -271,6 +271,32 @@ TEST(Rgbhsl, MidGraySafety) {
     EXPECT_LE(b, 1.0f + kEps);
 }
 
+TEST(Rgbhsl, BlueDominantPreservesBlueLuminosityOnRoundTrip) {
+    float h, s, l, r, g, b;
+    const float r0 = 0.1f;
+    const float g0 = 0.4f;
+    const float b0 = 0.8f;  // b > g > r: huezone 2 path.
+
+    rgb2hsl(r0, g0, b0, h, s, l);
+    // Regression: blue-dominant inputs must use blue as luminosity.
+    EXPECT_NEAR(l, b0, kEps);
+
+    hsl2rgb(h, s, l, r, g, b);
+    EXPECT_TRUE(std::isfinite(r));
+    EXPECT_TRUE(std::isfinite(g));
+    EXPECT_TRUE(std::isfinite(b));
+    EXPECT_GE(r, -kEps);
+    EXPECT_LE(r, 1.0f + kEps);
+    EXPECT_GE(g, -kEps);
+    EXPECT_LE(g, 1.0f + kEps);
+    EXPECT_GE(b, -kEps);
+    EXPECT_LE(b, 1.0f + kEps);
+
+    // Ensure round-trip brightness is not clipped to the original green channel.
+    float maxOut = std::fmax(r, std::fmax(g, b));
+    EXPECT_NEAR(maxOut, b0, kEps);
+}
+
 struct RgbColor {
     float r, g, b;
 };

--- a/tests/test_Rgbhsl.cpp
+++ b/tests/test_Rgbhsl.cpp
@@ -254,7 +254,10 @@ struct RgbColor {
 class RgbhslRoundTrip : public ::testing::TestWithParam<RgbColor> {};
 
 TEST_P(RgbhslRoundTrip, AllPrimarySecondaryRoundTrip) {
-    auto [r0, g0, b0] = GetParam();
+    RgbColor color = GetParam();
+    float r0 = color.r;
+    float g0 = color.g;
+    float b0 = color.b;
     float h, s, l, r, g, b;
     rgb2hsl(r0, g0, b0, h, s, l);
     hsl2rgb(h, s, l, r, g, b);

--- a/tests/test_Rgbhsl.cpp
+++ b/tests/test_Rgbhsl.cpp
@@ -295,6 +295,11 @@ TEST(Rgbhsl, BlueDominantPreservesBlueLuminosityOnRoundTrip) {
     // Ensure round-trip brightness is not clipped to the original green channel.
     float maxOut = std::fmax(r, std::fmax(g, b));
     EXPECT_NEAR(maxOut, b0, kEps);
+
+    // Also ensure full RGB round-trip fidelity for this blue-dominant case.
+    EXPECT_NEAR(r, r0, kEps);
+    EXPECT_NEAR(g, g0, kEps);
+    EXPECT_NEAR(b, b0, kEps);
 }
 
 struct RgbColor {

--- a/tests/test_Rgbhsl.cpp
+++ b/tests/test_Rgbhsl.cpp
@@ -255,10 +255,7 @@ TEST(Rgbhsl, MidGraySafety) {
     EXPECT_TRUE(std::isfinite(s));
     EXPECT_TRUE(std::isfinite(l));
     EXPECT_NEAR(l, 0.5f, kEps);
-    // This HSL model computes s = 1 - minChannel, so equal-channel grays
-    // (other than black/white) have non-zero saturation and do NOT round-trip
-    // to the original RGB values.  This test only verifies finite, in-range
-    // output to confirm no division-by-zero on a mid-gray input.
+    // Mid-gray should remain stable and finite through a round-trip conversion.
     hsl2rgb(h, s, l, r, g, b);
     EXPECT_TRUE(std::isfinite(r));
     EXPECT_TRUE(std::isfinite(g));
@@ -269,6 +266,9 @@ TEST(Rgbhsl, MidGraySafety) {
     EXPECT_LE(g, 1.0f + kEps);
     EXPECT_GE(b, -kEps);
     EXPECT_LE(b, 1.0f + kEps);
+    EXPECT_NEAR(r, 0.5f, kEps);
+    EXPECT_NEAR(g, 0.5f, kEps);
+    EXPECT_NEAR(b, 0.5f, kEps);
 }
 
 TEST(Rgbhsl, BlueDominantPreservesBlueLuminosityOnRoundTrip) {
@@ -323,5 +323,6 @@ INSTANTIATE_TEST_SUITE_P(PrimarySecondary, RgbhslRoundTrip,
         RgbColor{0.0f, 0.0f, 1.0f},  // Blue
         RgbColor{0.0f, 1.0f, 1.0f},  // Cyan
         RgbColor{1.0f, 0.0f, 1.0f},  // Magenta
-        RgbColor{1.0f, 1.0f, 0.0f}   // Yellow
+        RgbColor{1.0f, 1.0f, 0.0f},  // Yellow
+        RgbColor{0.6f, 0.0f, 0.3f}   // Dim magenta (max < 1.0)
     ));

--- a/tests/test_Rgbhsl.cpp
+++ b/tests/test_Rgbhsl.cpp
@@ -4,6 +4,7 @@
 
 #include <gtest/gtest.h>
 #include <cmath>
+#include <ostream>
 #include <Rgbhsl/Rgbhsl.h>
 
 static constexpr float kEps = 1e-3f;
@@ -305,6 +306,10 @@ TEST(Rgbhsl, BlueDominantPreservesBlueLuminosityOnRoundTrip) {
 struct RgbColor {
     float r, g, b;
 };
+
+void PrintTo(const RgbColor& c, std::ostream* os) {
+    *os << "{r=" << c.r << ", g=" << c.g << ", b=" << c.b << "}";
+}
 
 class RgbhslRoundTrip : public ::testing::TestWithParam<RgbColor> {};
 

--- a/tests/test_Rgbhsl.cpp
+++ b/tests/test_Rgbhsl.cpp
@@ -244,9 +244,9 @@ TEST(Rgbhsl, NearZeroLuminosity) {
     // Stay very dark and close to the original near-black input.
     float maxChannel = std::fmax(r, std::fmax(g, b));
     EXPECT_LE(maxChannel, kEps);
-    EXPECT_NEAR(r, 1e-8f, kEps);
-    EXPECT_NEAR(g, 1e-8f, kEps);
-    EXPECT_NEAR(b, 1e-8f, kEps);
+    EXPECT_NEAR(r, 0.0f, kEps);
+    EXPECT_NEAR(g, 0.0f, kEps);
+    EXPECT_NEAR(b, 0.0f, kEps);
 }
 
 TEST(Rgbhsl, MidGraySafety) {
@@ -307,7 +307,7 @@ struct RgbColor {
     float r, g, b;
 };
 
-void PrintTo(const RgbColor& c, std::ostream* os) {
+static void PrintTo(const RgbColor& c, std::ostream* os) {
     *os << "{r=" << c.r << ", g=" << c.g << ", b=" << c.b << "}";
 }
 

--- a/tests/test_Rgbhsl.cpp
+++ b/tests/test_Rgbhsl.cpp
@@ -232,6 +232,9 @@ TEST(Rgbhsl, GrayscaleRoundTrip) {
     EXPECT_TRUE(std::isfinite(s));
     EXPECT_TRUE(std::isfinite(l));
     EXPECT_NEAR(l, 0.5f, kEps);
+    // Note: this HSL model does not treat (0.5,0.5,0.5) as achromatic
+    // (s = 1 - minChannel = 0.5), so the round-trip produces a tinted color.
+    // We only verify finite, in-range output to confirm no division-by-zero.
     hsl2rgb(h, s, l, r, g, b);
     EXPECT_TRUE(std::isfinite(r));
     EXPECT_TRUE(std::isfinite(g));

--- a/tests/test_Rgbhsl.cpp
+++ b/tests/test_Rgbhsl.cpp
@@ -210,3 +210,62 @@ TEST(Rgbhsl, Grayscale) {
     rgb2hsl(0.0f, 0.0f, 0.0f, h, s, l);
     EXPECT_NEAR(l, 0.0f, kEps);
 }
+
+// ---------------------------------------------------------------------------
+// Division-by-zero guard and additional round-trip tests
+// ---------------------------------------------------------------------------
+
+TEST(Rgbhsl, NearZeroLuminosity) {
+    float h, s, l;
+    rgb2hsl(1e-8f, 1e-8f, 1e-8f, h, s, l);
+    EXPECT_TRUE(std::isfinite(h));
+    EXPECT_TRUE(std::isfinite(s));
+    EXPECT_TRUE(std::isfinite(l));
+    EXPECT_NEAR(l, 0.0f, kEps);
+    EXPECT_NEAR(h, 0.0f, kEps);
+}
+
+TEST(Rgbhsl, GrayscaleRoundTrip) {
+    float h, s, l, r, g, b;
+    rgb2hsl(0.5f, 0.5f, 0.5f, h, s, l);
+    EXPECT_TRUE(std::isfinite(h));
+    EXPECT_TRUE(std::isfinite(s));
+    EXPECT_TRUE(std::isfinite(l));
+    EXPECT_NEAR(l, 0.5f, kEps);
+    hsl2rgb(h, s, l, r, g, b);
+    EXPECT_TRUE(std::isfinite(r));
+    EXPECT_TRUE(std::isfinite(g));
+    EXPECT_TRUE(std::isfinite(b));
+    EXPECT_GE(r, 0.0f);
+    EXPECT_LE(r, 1.0f);
+    EXPECT_GE(g, 0.0f);
+    EXPECT_LE(g, 1.0f);
+    EXPECT_GE(b, 0.0f);
+    EXPECT_LE(b, 1.0f);
+}
+
+struct RgbColor {
+    float r, g, b;
+};
+
+class RgbhslRoundTrip : public ::testing::TestWithParam<RgbColor> {};
+
+TEST_P(RgbhslRoundTrip, AllPrimarySecondaryRoundTrip) {
+    auto [r0, g0, b0] = GetParam();
+    float h, s, l, r, g, b;
+    rgb2hsl(r0, g0, b0, h, s, l);
+    hsl2rgb(h, s, l, r, g, b);
+    EXPECT_NEAR(r, r0, kEps);
+    EXPECT_NEAR(g, g0, kEps);
+    EXPECT_NEAR(b, b0, kEps);
+}
+
+INSTANTIATE_TEST_SUITE_P(PrimarySecondary, RgbhslRoundTrip,
+    ::testing::Values(
+        RgbColor{1.0f, 0.0f, 0.0f},  // Red
+        RgbColor{0.0f, 1.0f, 0.0f},  // Green
+        RgbColor{0.0f, 0.0f, 1.0f},  // Blue
+        RgbColor{0.0f, 1.0f, 1.0f},  // Cyan
+        RgbColor{1.0f, 0.0f, 1.0f},  // Magenta
+        RgbColor{1.0f, 1.0f, 0.0f}   // Yellow
+    ));

--- a/tests/test_Rgbhsl.cpp
+++ b/tests/test_Rgbhsl.cpp
@@ -225,16 +225,17 @@ TEST(Rgbhsl, NearZeroLuminosity) {
     EXPECT_NEAR(h, 0.0f, kEps);
 }
 
-TEST(Rgbhsl, GrayscaleRoundTrip) {
+TEST(Rgbhsl, MidGraySafety) {
     float h, s, l, r, g, b;
     rgb2hsl(0.5f, 0.5f, 0.5f, h, s, l);
     EXPECT_TRUE(std::isfinite(h));
     EXPECT_TRUE(std::isfinite(s));
     EXPECT_TRUE(std::isfinite(l));
     EXPECT_NEAR(l, 0.5f, kEps);
-    // Note: this HSL model does not treat (0.5,0.5,0.5) as achromatic
-    // (s = 1 - minChannel = 0.5), so the round-trip produces a tinted color.
-    // We only verify finite, in-range output to confirm no division-by-zero.
+    // This HSL model computes s = 1 - minChannel, so equal-channel grays
+    // (other than black/white) have non-zero saturation and do NOT round-trip
+    // to the original RGB values.  This test only verifies finite, in-range
+    // output to confirm no division-by-zero on a mid-gray input.
     hsl2rgb(h, s, l, r, g, b);
     EXPECT_TRUE(std::isfinite(r));
     EXPECT_TRUE(std::isfinite(g));

--- a/tests/test_Rgbhsl.cpp
+++ b/tests/test_Rgbhsl.cpp
@@ -58,8 +58,8 @@ TEST(Rgbhsl, BlackSpecialCase) {
     rgb2hsl(0.0f, 0.0f, 0.0f, h, s, l);
     EXPECT_NEAR(l, 0.0f, kEps);
     EXPECT_NEAR(h, 0.0f, kEps);
-    // Saturation is undefined when luminosity is 0; the library returns 1.0
-    EXPECT_NEAR(s, 1.0f, kEps);
+    // Saturation is set to 0 for near-black inputs so round-trips stay achromatic.
+    EXPECT_NEAR(s, 0.0f, kEps);
 }
 
 TEST(Rgbhsl, RoundTripArbitraryColor) {
@@ -222,6 +222,30 @@ TEST(Rgbhsl, NearZeroLuminosity) {
     EXPECT_TRUE(std::isfinite(s));
     EXPECT_TRUE(std::isfinite(l));
     EXPECT_NEAR(l, 0.0f, kEps);
+
+    // For near-black input, hue is effectively undefined; instead of asserting
+    // a particular h value, verify that converting back via hsl2rgb produces
+    // a finite, in-range, near-black grayscale color (and close to the original).
+    float r, g, b;
+    hsl2rgb(h, s, l, r, g, b);
+    EXPECT_TRUE(std::isfinite(r));
+    EXPECT_TRUE(std::isfinite(g));
+    EXPECT_TRUE(std::isfinite(b));
+    EXPECT_GE(r, 0.0f);
+    EXPECT_LE(r, 1.0f);
+    EXPECT_GE(g, 0.0f);
+    EXPECT_LE(g, 1.0f);
+    EXPECT_GE(b, 0.0f);
+    EXPECT_LE(b, 1.0f);
+    // Remain grayscale: equal channels within epsilon.
+    EXPECT_NEAR(r, g, kEps);
+    EXPECT_NEAR(g, b, kEps);
+    // Stay very dark and close to the original near-black input.
+    float maxChannel = std::fmax(r, std::fmax(g, b));
+    EXPECT_LE(maxChannel, kEps);
+    EXPECT_NEAR(r, 1e-8f, kEps);
+    EXPECT_NEAR(g, 1e-8f, kEps);
+    EXPECT_NEAR(b, 1e-8f, kEps);
 }
 
 TEST(Rgbhsl, MidGraySafety) {

--- a/tests/test_Rgbhsl.cpp
+++ b/tests/test_Rgbhsl.cpp
@@ -222,7 +222,6 @@ TEST(Rgbhsl, NearZeroLuminosity) {
     EXPECT_TRUE(std::isfinite(s));
     EXPECT_TRUE(std::isfinite(l));
     EXPECT_NEAR(l, 0.0f, kEps);
-    EXPECT_NEAR(h, 0.0f, kEps);
 }
 
 TEST(Rgbhsl, MidGraySafety) {
@@ -240,12 +239,12 @@ TEST(Rgbhsl, MidGraySafety) {
     EXPECT_TRUE(std::isfinite(r));
     EXPECT_TRUE(std::isfinite(g));
     EXPECT_TRUE(std::isfinite(b));
-    EXPECT_GE(r, 0.0f);
-    EXPECT_LE(r, 1.0f);
-    EXPECT_GE(g, 0.0f);
-    EXPECT_LE(g, 1.0f);
-    EXPECT_GE(b, 0.0f);
-    EXPECT_LE(b, 1.0f);
+    EXPECT_GE(r, -kEps);
+    EXPECT_LE(r, 1.0f + kEps);
+    EXPECT_GE(g, -kEps);
+    EXPECT_LE(g, 1.0f + kEps);
+    EXPECT_GE(b, -kEps);
+    EXPECT_LE(b, 1.0f + kEps);
 }
 
 struct RgbColor {


### PR DESCRIPTION
This pull request improves robustness and correctness of the RGB-HSL conversion code in `Rgbhsl` and expands regression coverage for edge cases.

**Core conversion fixes**

- Replaced magic numbers with named `constexpr` constants for readability.
- Kept epsilon-based near-black guards to prevent invalid divisions/NaNs.
- Made near-black handling achromatic (`s = 0`) so near-zero round-trips do not bias toward red.
- Fixed luminosity selection for the blue-dominant `b > g > r` path so `l` uses the max channel (`b`).
- Restored luminosity-normalized saturation/hue calculations so chroma does not incorrectly depend on overall brightness.

**Build compatibility fixes**

- Updated legacy Makefiles to compile with `-std=c++14` (matching CMake test config).
- Added missing `<cstddef>` include in `Implicit/impSurface.h` for `size_t` under stricter standard settings.

**Test updates**

- Added/updated tests for near-zero luminosity finite behavior and round-trip stability.
- Added regression coverage for blue-dominant luminosity handling (`b > g > r`).
- Added dim-color (`max < 1.0`) round-trip coverage to catch brightness-dependent regressions.
- Kept C++14 compatibility in tests (no structured bindings).