### PR TITLE
Potential fixes for 3 code quality findings

### DIFF
--- a/rsWin32Saver/rsWin32Saver.cpp
+++ b/rsWin32Saver/rsWin32Saver.cpp
@@ -363,7 +363,7 @@ startScreenSaver(HWND parent)
 
 				if (dFrameRateLimit)
 				{  // frame rate is limited
-					timer.wait(1.0f / float(dFrameRateLimit));
+					timer.wait(desiredTimeStep);
 					idleProc();  // do idle processing (i.e. draw frames)
 					Sleep(0);
 				}

--- a/rsWin32Saver/rsWin32Saver.cpp
+++ b/rsWin32Saver/rsWin32Saver.cpp
@@ -348,7 +348,6 @@ startScreenSaver(HWND parent)
 
 		// variables for limiting frame rate
 		float desiredTimeStep = 0.0f;
-		float timeRemaining = 0.0f;
 		rsTimer timer;
 		if (dFrameRateLimit)
 			desiredTimeStep = 1.0f / float(dFrameRateLimit);

--- a/rsWin32Saver/rsWin32Saver.cpp
+++ b/rsWin32Saver/rsWin32Saver.cpp
@@ -178,7 +178,7 @@ WINAPI realScreenSaverProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
 }
 
 //-----------------------------------------------------------------------
-// Choose the best pixel format possible, giving preference to harware
+// Choose the best pixel format possible, giving preference to hardware
 // accelerated modes.
 
 void


### PR DESCRIPTION
_This PR applies 3/3 suggestions from code quality [AI findings](https://github.com/reallyslickscreensavers/rslibs/security/quality/ai-findings)._

This pull request makes minor improvements to the `rsWin32Saver.cpp` file, focusing on code clarity and correctness. The most notable changes are a spelling correction in a comment and a small refactor to the frame rate limiting logic.

Code clarity and correctness:

* Corrected a spelling error in a comment, changing "harware" to "hardware" in the pixel format selection section.

Frame rate limiting logic:

* Removed the unused `timeRemaining` variable from the frame rate limiting code in the `startScreenSaver` function.
* Refactored the frame rate limiting calculation to use the `desiredTimeStep` variable instead of recalculating the time step, improving readability and consistency.