### PR TITLE
feat(rsUtility): add rsUtility project files and configuration

### DIFF
--- a/rsUtility/rsUtility.vcxproj
+++ b/rsUtility/rsUtility.vcxproj
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{21A1A8B3-4602-4E4F-9E7A-9FE1F767B517}</ProjectGuid>
+    <Keyword>Utility</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Utility</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Utility</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>MultiByte</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+    <Import Project="$(VCTargetsPath)Microsoft.CPP.UpgradeFromVC71.props" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <ItemGroup>
+    <ClInclude Include="arguments.h" />
+    <ClInclude Include="catmullRom.h" />
+    <ClInclude Include="rsTimer.h" />
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/rsUtility/rsUtility.vcxproj.filters
+++ b/rsUtility/rsUtility.vcxproj.filters
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{93995380-89BD-4B04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="arguments.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="catmullRom.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="rsTimer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+</Project>

--- a/rslibs.sln
+++ b/rslibs.sln
@@ -11,6 +11,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Rgbhsl", "Rgbhsl\Rgbhsl.vcx
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "rsMath", "rsMath\rsMath.vcxproj", "{8CEDD5EF-0615-4517-8845-054E44B17E3C}"
 EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "rsUtility", "rsUtility\rsUtility.vcxproj", "{21A1A8B3-4602-4E4F-9E7A-9FE1F767B517}"
+EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "rsText", "rsText\rsText.vcxproj", "{6FADE693-C3CE-4183-B245-5F9878C5155C}"
 EndProject
 Global
@@ -33,6 +35,10 @@ Global
 		{8CEDD5EF-0615-4517-8845-054E44B17E3C}.Debug|x86.Build.0 = Debug|Win32
 		{8CEDD5EF-0615-4517-8845-054E44B17E3C}.Release|x86.ActiveCfg = Release|Win32
 		{8CEDD5EF-0615-4517-8845-054E44B17E3C}.Release|x86.Build.0 = Release|Win32
+		{21A1A8B3-4602-4E4F-9E7A-9FE1F767B517}.Debug|x86.ActiveCfg = Debug|Win32
+		{21A1A8B3-4602-4E4F-9E7A-9FE1F767B517}.Debug|x86.Build.0 = Debug|Win32
+		{21A1A8B3-4602-4E4F-9E7A-9FE1F767B517}.Release|x86.ActiveCfg = Release|Win32
+		{21A1A8B3-4602-4E4F-9E7A-9FE1F767B517}.Release|x86.Build.0 = Release|Win32
 		{6FADE693-C3CE-4183-B245-5F9878C5155C}.Debug|x86.ActiveCfg = Debug|Win32
 		{6FADE693-C3CE-4183-B245-5F9878C5155C}.Debug|x86.Build.0 = Debug|Win32
 		{6FADE693-C3CE-4183-B245-5F9878C5155C}.Release|x86.ActiveCfg = Release|Win32


### PR DESCRIPTION
This pull request adds a new utility project, `rsUtility`, to the solution. The main changes involve introducing the project files and integrating the project into the overall build system.

**Project Addition and Integration:**

* Added new project `rsUtility` to the solution, including its project file (`rsUtility.vcxproj`) and filter file (`rsUtility.vcxproj.filters`). This sets up the build configuration, platform toolset, and includes the header files `arguments.h`, `catmullRom.h`, and `rsTimer.h`. [[1]](diffhunk://#diff-80b7041caf5bf52f9fc5910701122fe2049cc854be00d768e361e5215bb53cfaR1-R49) [[2]](diffhunk://#diff-d67859bc0100f4ff9ee6de34f30731b4955a5049fc7248484356e611858c5f77R1-R20)
* Updated the solution file `rslibs.sln` to include the new `rsUtility` project and configured its build settings for Debug and Release configurations. [[1]](diffhunk://#diff-386b4020cd44805971f85f7c88f04f3d9ca75f1310ad8142b0371ad15a1b47eeR14-R15) [[2]](diffhunk://#diff-386b4020cd44805971f85f7c88f04f3d9ca75f1310ad8142b0371ad15a1b47eeR38-R41)