### PR TITLE
rsWin32Saver: increase frame rate limit slider max to 1000

### DIFF
--- a/rsWin32Saver/rsWin32Saver.cpp
+++ b/rsWin32Saver/rsWin32Saver.cpp
@@ -536,10 +536,10 @@ WinMain(HINSTANCE inst, HINSTANCE prevInst, LPSTR cmdLine, int cmdShow)
 void
 initFrameRateLimitSlider(HWND hdlg, int sliderID, int textID)
 {
-	SendDlgItemMessage(hdlg, sliderID, TBM_SETRANGE, 0, LPARAM(MAKELONG(DWORD(0), DWORD(120))));
+	SendDlgItemMessage(hdlg, sliderID, TBM_SETRANGE, 0, LPARAM(MAKELONG(DWORD(0), DWORD(1000))));
 	SendDlgItemMessage(hdlg, sliderID, TBM_SETPOS, 1, LPARAM(dFrameRateLimit));
 	SendDlgItemMessage(hdlg, sliderID, TBM_SETLINESIZE, 0, LPARAM(1));
-	SendDlgItemMessage(hdlg, sliderID, TBM_SETPAGESIZE, 0, LPARAM(10));
+	SendDlgItemMessage(hdlg, sliderID, TBM_SETPAGESIZE, 0, LPARAM(50));
 	char cval[16];
 	sprintf_s(cval, "%d", dFrameRateLimit);
 	SendDlgItemMessage(hdlg, textID, WM_SETTEXT, 0, LPARAM(cval));


### PR DESCRIPTION
## Summary
Increases the Frame Rate Limit slider maximum from 120 to 1000.

## Rationale
Modern GPUs and high-refresh-rate monitors (144, 240, 360+ Hz) can easily exceed 120 FPS. The current cap of 120 prevents users from setting a meaningful limit above that. Setting 0 (unlimited) works, but users may want a specific cap between 120 and 1000 to manage GPU thermals or power usage.

## Changes
- Slider range: 0-120 -> 0-1000
- Page size: 10 -> 50 (for easier navigation of the larger range)

Related: reallyslickscreensavers/reallyslickscreensavers#32 (vsync fix that makes the limiter actually work)